### PR TITLE
* moved all ast code into an ast namespace for easier distinction

### DIFF
--- a/grammar/CMakeLists.txt
+++ b/grammar/CMakeLists.txt
@@ -11,15 +11,20 @@ project(
 add_subdirectory(antlr)
 add_subdirectory(ast)
 
-add_library(FSharpGrammar INTERFACE)
+add_library(FSharpGrammar SHARED
+        Grammar.h
+        Grammar.cpp
+)
 target_link_libraries(FSharpGrammar
-    INTERFACE
+    PUBLIC
         FSharpGrammarAntlr
         FSharpGrammarAST
         antlr4_shared
+        ${FSHARP_MLIR_UTILITY_LIBS}
 )
-target_include_directories(FSharpGrammar INTERFACE
+target_include_directories(FSharpGrammar PUBLIC
     ${PROJECT_SOURCE_DIR}
+    ${FSHARP_MLIR_UTILITY_INCLUDES}
 )
 
 add_subdirectory(test)

--- a/grammar/Grammar.cpp
+++ b/grammar/Grammar.cpp
@@ -1,0 +1,68 @@
+//
+// Created by lasse on 06/01/2025.
+//
+
+#include "Grammar.h"
+
+#include <antlr4-runtime.h>
+#include <FSharpLexer.h>
+#include <FSharpParser.h>
+#include <magic_enum/magic_enum.hpp>
+
+#include "ast/AstBuilder.h"
+#include "utils/FunctionTimer.h"
+
+namespace fsharpgrammar
+{
+    void lex_source(const bool print_lexer_output, antlr4::CommonTokenStream& tokens)
+    {
+        tokens.fill();
+        if (print_lexer_output)
+        {
+            size_t lastLine = 0;
+            for (auto token : tokens.getTokens())
+            {
+                auto type = static_cast<decltype(FSharpLexer::UNKNOWN_CHAR)>(token->getType());
+                if (token->getLine() != lastLine)
+                    std::cout << std::endl << "Line " << token->getLine() << ": \n";
+                std::cout << magic_enum::enum_name(type) << ' ';
+                lastLine = token->getLine();
+            }
+        }
+    }
+
+    antlr4::tree::ParseTree* parse_source(const bool print_parser_output, FSharpParser& parser)
+    {
+        antlr4::tree::ParseTree* tree = parser.main();
+        if (print_parser_output)
+            std::cout << tree->toStringTree(&parser, true) << std::endl << std::endl;
+        return tree;
+    }
+
+    std::unique_ptr<ast::Main> Grammar::parse(const std::string_view source,
+                                              const bool print_lexer_output,
+                                              const bool print_parser_output,
+                                              const bool print_ast_output)
+    {
+        antlr4::ANTLRInputStream input(source);
+        FSharpLexer lexer(&input);
+        antlr4::CommonTokenStream tokens(&lexer);
+        lex_source(print_lexer_output, tokens);
+        std::cout << "Finished Lexing." << std::endl;
+
+        FSharpParser parser(&tokens);
+        antlr4::tree::ParseTree* const tree = parse_source(print_parser_output, parser);
+        std::cout << "Finished Parsing" << std::endl;
+
+
+        ast::AstBuilder builder;
+        auto ast = builder.BuildAst(dynamic_cast<FSharpParser::MainContext*>(tree));
+
+        if (print_ast_output)
+        {
+            std::string ast_string = utils::to_string(*ast);
+            fmt::print("AST Generation Result = \n{}\n", *ast);
+        }
+        return ast;
+    }
+} // fsharpgrammar

--- a/grammar/Grammar.h
+++ b/grammar/Grammar.h
@@ -1,0 +1,22 @@
+//
+// Created by lasse on 06/01/2025.
+//
+
+#pragma once
+
+#include <string>
+
+#include "ast/ASTHelper.h"
+#include "ast/ASTNode.h"
+
+namespace fsharpgrammar
+{
+    class Grammar
+    {
+    public:
+        static std::unique_ptr<ast::Main> parse(std::string_view source,
+                                             bool print_lexer_output = true,
+                                             bool print_parser_output = true,
+                                             bool print_ast_output = true);
+    };
+} // fsharpgrammar

--- a/grammar/ast/ASTHelper.h
+++ b/grammar/ast/ASTHelper.h
@@ -4,17 +4,21 @@
 
 #pragma once
 
-#include "ASTNode.h"
-#include "FSharpParser.h"
-#include "Range.h"
-#include "fmt/format.h"
+#include <any>
+#include <memory>
+
+#include <antlr4-runtime.h>
+#include <fmt/format.h>
+#include <cpptrace/cpptrace.hpp>
 
 #include "utils/Utils.h"
-#include "cpptrace/cpptrace.hpp"
-
+#include "Range.h"
 
 namespace fsharpgrammar::ast
 {
+    template <typename T>
+        using ast_ptr = std::shared_ptr<T>;
+
     template<typename T>
     ast_ptr<T> any_cast(std::any& obj, antlr4::ParserRuleContext *parserRuleContext)
     {

--- a/grammar/ast/ASTNode.cpp
+++ b/grammar/ast/ASTNode.cpp
@@ -11,7 +11,7 @@
     std::stringstream ss; \
     ss << fmt::format("{} {}\n", Name, utils::to_string(Object.get_range()))
 
-namespace fsharpgrammar
+namespace fsharpgrammar::ast
 {
     Main::Main(
         std::vector<ast_ptr<ModuleOrNamespace>>&& modules_or_namespaces,
@@ -46,7 +46,7 @@ namespace fsharpgrammar
     }
 
     ModuleDeclaration::Expression::Expression(
-        ast_ptr<fsharpgrammar::Expression>&& expression,
+        ast_ptr<ast::Expression>&& expression,
         Range&& range)
         :
         expression(std::move(expression)),

--- a/grammar/ast/AstBuilder.cpp
+++ b/grammar/ast/AstBuilder.cpp
@@ -8,8 +8,13 @@
 #include "ASTHelper.h"
 #include "utils/FunctionTimer.h"
 
-namespace fsharpgrammar
+namespace fsharpgrammar::ast
 {
+    std::unique_ptr<Main> AstBuilder::BuildAst(FSharpParser::MainContext* ctx)
+    {
+        return std::unique_ptr<Main>(std::any_cast<Main*>(visitMain(ctx)));
+    }
+
     std::any AstBuilder::visitMain(FSharpParser::MainContext* ctx)
     {
         std::vector<ast_ptr<ModuleOrNamespace>> anon_modules;
@@ -17,7 +22,7 @@ namespace fsharpgrammar
         {
             anon_modules.push_back(ast::any_cast<ModuleOrNamespace>(module_or_namespace->accept(this), ctx));
         }
-        return make_ast<Main>(std::move(anon_modules), Range::create(ctx));
+        return new Main(std::move(anon_modules), Range::create(ctx));
     }
 
     std::vector<ast_ptr<ModuleDeclaration>> get_module_declarations(
@@ -601,7 +606,7 @@ namespace fsharpgrammar
 
     std::any AstBuilder::visitNew_expr(FSharpParser::New_exprContext* context)
     {
-        auto type = ast::any_cast<fsharpgrammar::Type>(context->type()->accept(this), context);
+        auto type = ast::any_cast<Type>(context->type()->accept(this), context);
         std::optional<ast_ptr<Expression>> expression{};
         if (context->expression())
         {

--- a/grammar/ast/AstBuilder.h
+++ b/grammar/ast/AstBuilder.h
@@ -6,19 +6,29 @@
 #include "FSharpParser.h"
 #include "FSharpParserBaseVisitor.h"
 
-namespace fsharpgrammar {
+namespace fsharpgrammar::ast
+{
+    class Main;
+}
 
+namespace fsharpgrammar::ast
+{
     using namespace antlr4;
 
-    class AstBuilder final : FSharpParserBaseVisitor {
+    class AstBuilder final : FSharpParserBaseVisitor
+    {
     public:
+        std::unique_ptr<Main> BuildAst(FSharpParser::MainContext* ctx);
+
+    protected:
         // main
-        std::any visitMain(FSharpParser::MainContext *ctx) override;
+        // Returns a raw pointer. Should be converted to a unique_ptr immediately.
+        std::any visitMain(FSharpParser::MainContext* ctx) override;
 
         // module_or_namespace
         std::any visitAnonmodule(FSharpParser::AnonmoduleContext* context) override;
         std::any visitNamedmodule(FSharpParser::NamedmoduleContext* context) override;
-        std::any visitNamespace(FSharpParser::NamespaceContext *ctx) override;
+        std::any visitNamespace(FSharpParser::NamespaceContext* ctx) override;
 
         // module_decl
         std::any visitEmply_lines(FSharpParser::Emply_linesContext* context) override;
@@ -33,7 +43,7 @@ namespace fsharpgrammar {
         // expression
         std::any visitInline_sequential_stmt(FSharpParser::Inline_sequential_stmtContext* context) override;
         std::any visitSequential_stmt(FSharpParser::Sequential_stmtContext* context) override;
-        std::any visitExpression(FSharpParser::ExpressionContext *ctx) override;
+        std::any visitExpression(FSharpParser::ExpressionContext* ctx) override;
 
         // non assignment expression
         std::any visitNon_assigment_expr(FSharpParser::Non_assigment_exprContext* context) override;
@@ -116,4 +126,3 @@ namespace fsharpgrammar {
         std::any visitNull_pat(FSharpParser::Null_patContext* context) override;
     };
 } // fsharpgrammar
-

--- a/grammar/ast/Range.cpp
+++ b/grammar/ast/Range.cpp
@@ -7,7 +7,7 @@
 #include <ParserRuleContext.h>
 #include <Token.h>
 
-namespace fsharpgrammar
+namespace fsharpgrammar::ast
 {
     Range Range::create(const antlr4::ParserRuleContext* ctx)
     {

--- a/grammar/ast/Range.h
+++ b/grammar/ast/Range.h
@@ -15,7 +15,7 @@ namespace antlr4
     class ParserRuleContext;
 }
 
-namespace fsharpgrammar
+namespace fsharpgrammar::ast
 {
     constexpr int64_t pown64(int32_t n)
     {
@@ -101,16 +101,16 @@ namespace fsharpgrammar
 namespace std
 {
     template<>
-    struct hash<fsharpgrammar::Position>
+    struct hash<fsharpgrammar::ast::Position>
     {
-        size_t operator()(const fsharpgrammar::Position& pos) const noexcept
+        size_t operator()(const fsharpgrammar::ast::Position& pos) const noexcept
         {
             return hash<int64_t>()(pos.Encoding);
         }
     };
 }
 
-namespace fsharpgrammar {
+namespace fsharpgrammar::ast {
     static constexpr int32_t StartColumnBitCount = ColumnBitCount;
     static constexpr int32_t EndColumnBitCount = ColumnBitCount;
     static constexpr int32_t StartLineBitCount = LineBitCount;

--- a/grammar/test/CMakeLists.txt
+++ b/grammar/test/CMakeLists.txt
@@ -12,13 +12,11 @@ add_executable(FSharpGrammarTest
 # include generated files in project environment
 target_include_directories(FSharpGrammarTest PRIVATE
         ${PROJECT_SOURCE_DIR}/../
-        ${FSHARP_MLIR_UTILITY_INCLUDES}
 )
 
 target_link_libraries(FSharpGrammarTest
         PRIVATE
         FSharpGrammar
-        ${FSHARP_MLIR_UTILITY_LIBS}
 )
 
 

--- a/grammar/test/GTEST/CMakeLists.txt
+++ b/grammar/test/GTEST/CMakeLists.txt
@@ -7,14 +7,14 @@ add_executable(GrammarTests
 target_include_directories(GrammarTests
         PRIVATE
         ${PROJECT_SOURCE_DIR}/../
-        ${FSHARP_MLIR_UTILITY_INCLUDES})
+)
 
 target_link_libraries(GrammarTests
         PRIVATE
         GTest::gtest_main
 
+        PUBLIC
         FSharpGrammar
-        ${FSHARP_MLIR_UTILITY_LIBS}
 )
 
 include(GoogleTest)

--- a/grammar/test/GTEST/tests.cpp
+++ b/grammar/test/GTEST/tests.cpp
@@ -3,50 +3,16 @@
 //
 
 #include "antlr4-runtime.h"
-#include "FSharpLexer.h"
-#include "FSharpParser.h"
 
 #include <fstream>
 #include <gtest/gtest.h>
 
-#include "utils/Utils.h"
-#include "utils/FunctionTimer.h"
-#include "magic_enum/magic_enum.hpp"
-
-#include "ast/AstBuilder.h"
-#include "ast/ASTNode.h"
+#include "Grammar.h"
 
 #define AST_GENERATION_TEST(Name, Type, SourceCode) \
 TEST(Name, Type) \
 { \
-    antlr4::ANTLRInputStream input(SourceCode); \
-    fsharpgrammar::FSharpLexer lexer(&input);\
-    antlr4::CommonTokenStream tokens(&lexer);\
-    \
-    tokens.fill();\
-    size_t lastLine = 0;\
-    for (auto token : tokens.getTokens())\
-    {\
-        auto type = static_cast<decltype(fsharpgrammar::FSharpLexer::UNKNOWN_CHAR)>(token->getType());\
-        if (token->getLine() != lastLine)\
-            std::cout << std::endl << "Line " << token->getLine() << ": \n";\
-        std::cout << magic_enum::enum_name(type) << ' ';\
-        lastLine = token->getLine();\
-    }\
-    \
-    std::cout << "Finished Lexing." << std::endl;\
-    \
-    fsharpgrammar::FSharpParser parser(&tokens);\
-    antlr4::tree::ParseTree* tree = parser.main();\
-    \
-    /* std::cout << tree->toStringTree(&parser, true) << std::endl << std::endl; */ \
-    std::cout << "Simplifying tree" << std::endl;\
-    \
-    fsharpgrammar::AstBuilder builder;\
-    auto ast = std::any_cast<fsharpgrammar::ast_ptr<fsharpgrammar::Main>>(builder.visitMain(dynamic_cast<fsharpgrammar::FSharpParser::MainContext*>(tree)));\
-    std::string ast_string = utils::to_string(*ast);\
-    \
-    fmt::print("AST Generation Result = \n{}\n", *ast);\
+    fsharpgrammar::Grammar::parse(SourceCode, true, false, true); \
 }
 
 namespace basic_statements

--- a/utils/utils/FunctionTimer.cpp
+++ b/utils/utils/FunctionTimer.cpp
@@ -1,24 +1,32 @@
 #include "FunctionTimer.h"
 
-std::unordered_map<std::string, double> FunctionTimer::timings;
-std::mutex FunctionTimer::timingsMutex;
+namespace utils
+{
+    std::unordered_map<std::string, double> FunctionTimer::timings;
+    std::mutex FunctionTimer::timingsMutex;
 
-FunctionTimer::FunctionTimer(const std::string& functionName)
-    : functionName(functionName),
-      startTime(std::chrono::high_resolution_clock::now()) {}
+    FunctionTimer::FunctionTimer(const std::string& functionName)
+        : functionName(functionName),
+          startTime(std::chrono::high_resolution_clock::now())
+    {
+    }
 
-FunctionTimer::~FunctionTimer() {
-    auto endTime = std::chrono::high_resolution_clock::now();
-    double duration = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
+    FunctionTimer::~FunctionTimer()
+    {
+        auto endTime = std::chrono::high_resolution_clock::now();
+        long duration = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
 
-    std::lock_guard<std::mutex> lock(timingsMutex);
-    timings[functionName] += duration / 1000.0; // Convert to milliseconds
-}
+        std::lock_guard<std::mutex> lock(timingsMutex);
+        timings[functionName] += duration / 1000.0; // Convert to milliseconds
+    }
 
-void FunctionTimer::PrintTimings() {
-    std::lock_guard<std::mutex> lock(timingsMutex);
-    std::cout << "Function Execution Times:" << std::endl;
-    for (const auto& [name, time] : timings) {
-        std::cout << name << ": " << time << " ms" << std::endl;
+    void FunctionTimer::PrintTimings()
+    {
+        std::lock_guard<std::mutex> lock(timingsMutex);
+        std::cout << "Function Execution Times:" << std::endl;
+        for (const auto& [name, time] : timings)
+        {
+            std::cout << name << ": " << time << " ms" << std::endl;
+        }
     }
 }

--- a/utils/utils/FunctionTimer.h
+++ b/utils/utils/FunctionTimer.h
@@ -10,17 +10,21 @@
 #include <unordered_map>
 #include <mutex>
 
-class FunctionTimer {
-public:
-    FunctionTimer(const std::string& functionName);
-    ~FunctionTimer();
+namespace utils
+{
+    class FunctionTimer
+    {
+    public:
+        FunctionTimer(const std::string& functionName);
+        ~FunctionTimer();
 
-    static void PrintTimings();
+        static void PrintTimings();
 
-private:
-    static std::unordered_map<std::string, double> timings;
-    static std::mutex timingsMutex;
+    private:
+        static std::unordered_map<std::string, double> timings;
+        static std::mutex timingsMutex;
 
-    std::string functionName;
-    std::chrono::high_resolution_clock::time_point startTime;
-};
+        std::string functionName;
+        std::chrono::high_resolution_clock::time_point startTime;
+    };
+}


### PR DESCRIPTION
* added grammar.h and grammar.cpp for easier api access of the parser
* using grammar.h for test cases now